### PR TITLE
Pangram test with non-ASCII characters, closes #53

### DIFF
--- a/exercises/pangram/test/Main.purs
+++ b/exercises/pangram/test/Main.purs
@@ -41,6 +41,6 @@ main = runTest do
       Assert.equal true $
         isPangram "\"Five quacking Zephyrs jolt my wax bed.\""
 
-    test "pangram with non ascii characters" do
-      Assert.equal true $
-        isPangram "Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich."
+    test "upper and lower case versions of the same character should not be counted separately" do
+      Assert.equal false $
+        isPangram "the quick brown fox jumped over the lazy FOX"


### PR DESCRIPTION
Update for https://github.com/exercism/purescript/issues/53 to remove non-ASCII test and sync up with canonical data:

https://github.com/exercism/problem-specifications/blob/f375051787370bd1af1dd84e8d6c116f07d88ad2/exercises/pangram/canonical-data.json

