### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,42 +5,60 @@
   "active": false,
   "exercises": [
     {
+      "uuid": "c41a2961-f7ca-4eaf-83cf-48762fc39c06",
       "slug": "hello-world",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "maybe"
       ]
     },
     {
+      "uuid": "1a95beb7-5bb2-44c4-aee7-5790bcb38865",
       "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "modulo"
       ]
     },
     {
+      "uuid": "021a1f60-6086-4d8f-a8be-0f64cfd9620d",
       "slug": "bob",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings"
       ]
     },
     {
+      "uuid": "f0ce38ee-402f-451d-abd0-e3dc56d5cde4",
       "slug": "raindrops",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "modulo"
       ]
     },
     {
+      "uuid": "3cd10a88-9cc0-4dcd-a2f3-1f5bcb5eaf07",
       "slug": "hamming",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Iterating over two lists at once"
       ]
     },
     {
+      "uuid": "aaf7a72c-ada0-4e43-8cc1-78d9e60ee151",
       "slug": "pangram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings",
@@ -48,7 +66,10 @@
       ]
     },
     {
+      "uuid": "c956e70b-4e34-451b-9374-19b9f2aefa37",
       "slug": "scrabble-score",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings",
@@ -56,7 +77,10 @@
       ]
     },
     {
+      "uuid": "d530077b-1eed-44cd-9791-5f78001c7372",
       "slug": "accumulate",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "recursion",
@@ -65,7 +89,10 @@
       ]
     },
     {
+      "uuid": "79a091fa-7987-44e1-9146-fffa28352ee2",
       "slug": "acronym",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "strings",
@@ -73,7 +100,10 @@
       ]
     },
     {
+      "uuid": "d8d3d3dd-01f8-4289-afe2-60595a580240",
       "slug": "triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "algebraic data types",
@@ -81,35 +111,50 @@
       ]
     },
     {
+      "uuid": "d9bda7fe-51c1-42f0-9631-fcb7ddd163b8",
       "slug": "word-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings"
       ]
     },
     {
+      "uuid": "d0942b01-fe68-46b3-be66-8e19592f666b",
       "slug": "meetup",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "dates"
       ]
     },
     {
+      "uuid": "d077a175-2219-439c-9bfa-3098239e4cd6",
       "slug": "atbash-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings"
       ]
     },
     {
+      "uuid": "dd60d894-9bab-4d53-96a2-11e77aa3e7f8",
       "slug": "bracket-push",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "dates"
       ]
     },
     {
+      "uuid": "9270773b-20f0-4e82-b0fd-e651af9d8415",
       "slug": "allergies",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "maps",
@@ -117,35 +162,50 @@
       ]
     },
     {
+      "uuid": "79011a26-c8b8-4fea-bdce-f8e3d37bee23",
       "slug": "all-your-base",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "base conversion"
       ]
     },
     {
+      "uuid": "0029ced5-503b-4491-a309-7f0176598dd0",
       "slug": "binary-search",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "binary search"
       ]
     },
     {
+      "uuid": "864d3c8b-fffe-4228-87f3-a56173b14eb4",
       "slug": "difference-of-squares",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "arithmetics"
       ]
     },
     {
+      "uuid": "bbaa71d1-be6a-444f-8661-006a40ef8a09",
       "slug": "diamond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings"
       ]
     },
     {
+      "uuid": "e4f49f2e-87bd-4506-9184-d90bec0adde5",
       "slug": "crypto-square",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings",
@@ -153,7 +213,10 @@
       ]
     },
     {
+      "uuid": "9cb54162-d19c-4155-aca9-e2b26f4d4da5",
       "slug": "isogram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings",
@@ -161,29 +224,35 @@
       ]
     },
     {
+      "uuid": "750d7b11-8201-4a83-b743-f2751d1743f6",
       "slug": "etl",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "maps"
       ]
     },
     {
+      "uuid": "78527833-8200-4085-8427-650aafb1990c",
       "slug": "largest-series-product",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings"
       ]
     },
     {
+      "uuid": "83b533f1-a712-4d6a-bc97-505c6e7c9161",
       "slug": "pascals-triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "arrays"
       ]
     }
-  ],
-  "deprecated": [
-
   ],
   "foregone": [
 


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

Until now we have operated with a separate deprecated array. These are now being moved into the exercises array with a deprecated field.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.

If you haven't already, now would be a good time to do the following:

* add a rough estimate of difficulty to each exercise (scale: 1-10)
* add topics to each exercise
* choose *at most 20 exercises* to be core exercises (set core: true, and delete the unlocked_by key)
* for each exercise that is not core, decide which exercise is the prerequisite (max 1)

If possible, leave 3 or 4 simple exercises as (core: false, unlocked_by: null), as this will provide new participants with some exercises that they can tackle even if they have not finished the first core exercise.


See https://github.com/exercism/meta/issues/16