### PR TITLE
Add update-bower.sh and update bower.json of all exercises

### DIFF
--- a/bin/update-bower.sh
+++ b/bin/update-bower.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# This script will update bower.json of all exercises
+# using the master bower.json in etc/bower.json
+# 
+# To keep the dependencies in sync and aid the Travis build
+# please only update the master bower.json
+
+xpurescript=$(dirname "$BASH_SOURCE")
+xpurescript=$(readlink -f "$xpurescript/..")
+cd "$xpurescript/exercises"
+
+bower_master="$xpurescript/etc/bower.json"
+
+for exercise in *; do
+  bower=$exercise/bower.json
+
+  if [[ -f $bower ]]; then
+    echo Updating $bower
+
+    cp $bower_master $bower
+    sed -i -r 's/"name": "purescript-exercise",/"name": "'$exercise'",/' $bower
+  fi
+done
+

--- a/exercises/accumulate/bower.json
+++ b/exercises/accumulate/bower.json
@@ -7,10 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/acronym/bower.json
+++ b/exercises/acronym/bower.json
@@ -7,11 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0",
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
     "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/all-your-base/bower.json
+++ b/exercises/all-your-base/bower.json
@@ -7,10 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/allergies/bower.json
+++ b/exercises/allergies/bower.json
@@ -7,12 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0",
-    "purescript-maps": "^3.0.0",
-    "purescript-integers": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/atbash-cipher/bower.json
+++ b/exercises/atbash-cipher/bower.json
@@ -7,12 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0",
-    "purescript-maps": "^3.0.0",
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
     "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/binary-search/bower.json
+++ b/exercises/binary-search/bower.json
@@ -7,10 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/bob/bower.json
+++ b/exercises/bob/bower.json
@@ -7,11 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0",
-    "purescript-console": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/bracket-push/bower.json
+++ b/exercises/bracket-push/bower.json
@@ -7,11 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0",
-    "purescript-lists": "^4.0.1"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/crypto-square/bower.json
+++ b/exercises/crypto-square/bower.json
@@ -7,12 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0",
-    "purescript-strings": "^3.0.0",
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
     "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/diamond/bower.json
+++ b/exercises/diamond/bower.json
@@ -7,11 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0",
-    "purescript-enums": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/difference-of-squares/bower.json
+++ b/exercises/difference-of-squares/bower.json
@@ -7,10 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/etl/bower.json
+++ b/exercises/etl/bower.json
@@ -7,11 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0",
-    "purescript-maps": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/hamming/bower.json
+++ b/exercises/hamming/bower.json
@@ -7,10 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/hello-world/bower.json
+++ b/exercises/hello-world/bower.json
@@ -7,11 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0",
-    "purescript-console": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/isogram/bower.json
+++ b/exercises/isogram/bower.json
@@ -7,12 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0",
-    "purescript-maps": "^3.0.0",
-    "purescript-strings": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/largest-series-product/bower.json
+++ b/exercises/largest-series-product/bower.json
@@ -7,10 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/leap/bower.json
+++ b/exercises/leap/bower.json
@@ -7,10 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/meetup/bower.json
+++ b/exercises/meetup/bower.json
@@ -7,11 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0",
-    "purescript-datetime": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/pangram/bower.json
+++ b/exercises/pangram/bower.json
@@ -7,11 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0",
-    "purescript-sets": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/pascals-triangle/bower.json
+++ b/exercises/pascals-triangle/bower.json
@@ -5,12 +5,22 @@
     "node_modules",
     "bower_components",
     "output"
-  ],  
+  ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0"
-  },  
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
+  },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/raindrops/bower.json
+++ b/exercises/raindrops/bower.json
@@ -7,10 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/scrabble-score/bower.json
+++ b/exercises/scrabble-score/bower.json
@@ -7,10 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/triangle/bower.json
+++ b/exercises/triangle/bower.json
@@ -7,13 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0",
     "purescript-console": "^3.0.0",
-    "purescript-either": "^3.0.0",
-    "purescript-sets": "^3.0.0"
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }

--- a/exercises/word-count/bower.json
+++ b/exercises/word-count/bower.json
@@ -7,11 +7,20 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0",
-    "purescript-maps": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-datetime": "^3.4.0",
+    "purescript-either": "^3.1.0",
+    "purescript-enums": "^3.2.1",
+    "purescript-integers": "^3.1.0",
+    "purescript-lists": "^4.10.0",
+    "purescript-maps": "^3.5.2",
+    "purescript-prelude": "^3.1.0",
+    "purescript-sets": "^3.0.0",
+    "purescript-strings": "^3.3.1",
+    "purescript-unicode": "^3.0.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^13.0.0"
   }
 }


### PR DESCRIPTION
Continuation of https://github.com/exercism/purescript/pull/71.

Fixes this:

* Fix each of the exercises (it should be only copying the bower.json, but need to confirm)
* Add a script to copy the common bower.json to all exercises to help with the development

Remaining:

* Add dependency checker to the build which would confirm that all exercises are using the same versions as the common bower.json
* Update documentation for contributing to mention the additional restrictions

@lpil please check it out if you have a moment.