### PR TITLE
Add bower checker, update travis to use it and add separate testing script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
 script:
   - bin/fetch-configlet
   - bin/configlet lint .
+  - bin/check-bower.sh
   - bin/test.sh
 
 cache:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ As a first step we recommend you read the [contributing guide][cont-guide].
 
 [cont-guide]: https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md
 
+Due to Travis builds taking too long and timing out, the current build plan compiles and runs the tests for all exercises in a single run. This requires the following:
+
+- A master bower is given in `etc/bower.json`. Test scripts assure this one is used when they are run
+  * Please only update the master one and then run `bin/update-bower.sh` to sync them up. 
+  * After editing `etc/bower.json`, it is advisable to run `bin/check-bower.sh`. This checks for any discrepancies between various bower scripts.
+- Make sure exercises have a single module in `examples/src`
+
+See [this PR](https://github.com/exercism/purescript/pull/71) for more details and the background.
+
 #### Reporting or fixing bugs
 
 Typical examples for a bug: A typo, a missing test case, an unclear or

--- a/bin/check-bower.sh
+++ b/bin/check-bower.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# This script will check bower.json of all exercises
+# to confirm there are no discrepancies between them
+# and the master bower.json in etc/bower.json
+
+xpurescript=$(dirname "$BASH_SOURCE")
+xpurescript=$(readlink -f "$xpurescript/..")
+cd "$xpurescript/exercises"
+
+bower_master="$xpurescript/etc/bower.json"
+md5_master=$(md5sum $bower_master | awk '{print $1}')
+
+check_result_all=0
+
+for exercise in *; do
+  bower=$exercise/bower.json
+
+  if [[ -f $bower ]]; then
+    md5=$(sed -r 's/"name": "'$exercise'",/"name": "purescript-exercise",/' $bower | md5sum | awk '{print $1}')
+
+    check_result=0
+    if [[ $md5_master != $md5 ]]; then
+      check_result=1
+      check_result_all=1
+    fi
+
+    if [[ $check_result == 0 ]]; then
+      echo -e "\e[1;32mOK     $bower\e[0;39m"
+    else
+      echo -e "\e[1;31mNOT OK $bower\e[0;39m"
+    fi
+  fi
+done
+
+if [[ $check_result_all != 0 ]]; then
+  echo -e "\e[1;31m"
+  echo -e "Please check Contributing section in README for more information about fixing the above issues."
+  echo -e "\e[0;39m"
+fi
+
+exit $check_result_all

--- a/bin/test-separate.sh
+++ b/bin/test-separate.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+xpurescript=$(dirname "$BASH_SOURCE")
+xpurescript=$(readlink -f "$xpurescript/..")
+cd "$xpurescript/exercises"
+
+# Calling the script with 'clean' as the first argument
+# will cause a fully clean build
+
+clean=no
+if [[ "$1" == clean ]]; then
+  clean=yes
+fi
+
+# Run for all exercises
+
+for exercise in *; do
+  if [[ -f $exercise/bower.json ]]; then
+    cd $exercise
+
+    echo
+    echo -e "\e[1;32m--- [ $exercise ]\e[0;39m"
+    echo
+
+    # Clean local caches if clean build was requested
+    if [[ $clean == yes ]]; then
+      rm -rf bower_components output .pulp-cache
+    fi
+
+    # Move the example solution temporarily
+    if [[ ! -d src.tmp ]]; then
+      mv src src.tmp
+      mv examples/src src
+    fi
+
+    # Install and test
+    bower install
+    pulp test
+
+    # Revert to the previous state
+    mv src examples/src
+    mv src.tmp src
+
+    cd ..
+  fi
+done


### PR DESCRIPTION
Continuation of https://github.com/exercism/purescript/pull/72

* Add dependency checker to the build which would confirm that all exercises are using the same versions as the common bower.json
* Update documentation for contributing to mention the additional restrictions
* Adds test-separate.sh that can be used to compile and test all exercises separately, instead of merging them like test.sh used in Travis build does. Had it built for previous testing, so figured I can include it. Might be useful down the road...

This completes things mentioned in https://github.com/exercism/purescript/pull/71.

@lpil please check if all good when you get a chance.