### PR TITLE
fix broken link in INSTALLING.md

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -7,6 +7,4 @@ compiler, the Pulp build tool and the Bower package manager.
 
     npm install --global purescript pulp bower
 
-More information can be found in [the Purescript repository][ps-repo]
-
-[ps-repo]: (https://github.com/purescript/purescript/blob/master/INSTALL.md).
+More information can be found in [the Purescript repository](https://github.com/purescript/purescript/blob/master/INSTALL.md).


### PR DESCRIPTION
Fixes a broken link in INSTALLING.md - on [the install page](http://exercism.io/languages/purescript/installation) the link currently ends up in a 404.