### PR TITLE
Add 'math' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -168,7 +168,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "base_conversion"
+        "base_conversion",
+        "math"
       ]
     },
     {
@@ -188,7 +189,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "arithmetics"
+        "arithmetics",
+        "math"
       ]
     },
     {
@@ -240,6 +242,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
+        "math",
         "strings"
       ]
     },
@@ -250,7 +253,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "arrays"
+        "arrays",
+        "math"
       ]
     },
     {
@@ -261,6 +265,7 @@
       "difficulty": 1,
       "topics": [
         "arithmetics",
+        "math",
         "maybe"
       ]
     },
@@ -273,6 +278,7 @@
       "topics": [
         "arithmetics",
         "arrays",
+        "math",
         "modulo"
       ]
     },


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.

This updates any 'mathematics' topics to be 'math' since it's shorter
and won't get cropped in the UI.

It also removes the math topics for any exercises that are not in the
canonical math-y list.


exercism/exercism.io#4110