### PR TITLE
support purescript 0.13.x

### DIFF
--- a/etc/bower.json
+++ b/etc/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/accumulate/bower.json
+++ b/exercises/accumulate/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/acronym/bower.json
+++ b/exercises/acronym/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/all-your-base/bower.json
+++ b/exercises/all-your-base/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/allergies/bower.json
+++ b/exercises/allergies/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/atbash-cipher/bower.json
+++ b/exercises/atbash-cipher/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/binary-search/bower.json
+++ b/exercises/binary-search/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/bob/bower.json
+++ b/exercises/bob/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/bracket-push/bower.json
+++ b/exercises/bracket-push/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/collatz-conjecture/bower.json
+++ b/exercises/collatz-conjecture/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/crypto-square/bower.json
+++ b/exercises/crypto-square/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/diamond/bower.json
+++ b/exercises/diamond/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/difference-of-squares/bower.json
+++ b/exercises/difference-of-squares/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/etl/bower.json
+++ b/exercises/etl/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/hamming/bower.json
+++ b/exercises/hamming/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/hello-world/bower.json
+++ b/exercises/hello-world/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/isogram/bower.json
+++ b/exercises/isogram/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/largest-series-product/bower.json
+++ b/exercises/largest-series-product/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/leap/bower.json
+++ b/exercises/leap/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/meetup/bower.json
+++ b/exercises/meetup/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/pangram/bower.json
+++ b/exercises/pangram/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/pascals-triangle/bower.json
+++ b/exercises/pascals-triangle/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/phone-number/bower.json
+++ b/exercises/phone-number/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/raindrops/bower.json
+++ b/exercises/raindrops/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/rna-transcription/bower.json
+++ b/exercises/rna-transcription/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/scrabble-score/bower.json
+++ b/exercises/scrabble-score/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/sum-of-multiples/bower.json
+++ b/exercises/sum-of-multiples/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/triangle/bower.json
+++ b/exercises/triangle/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }

--- a/exercises/word-count/bower.json
+++ b/exercises/word-count/bower.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^15.0.0"
   }
 }


### PR DESCRIPTION
There has been some confusion caused by people following the given directions to install purescript, which installs version 0.13.2.  The confusion is caused when they try to build an exercise, and the build fails.

This is because `purescript` version 0.13.x requires `purescript-typelevel-prelude` version `v5.0.0` to work.

This PR bumps the version of `purescript-test-unit` to `v15.0.0`, which transitively updates the version of `purescript-typelevel-prelude` as well.

Note that this should still work with purescript v12.2.2 and up (see https://github.com/purescript/purescript-typelevel-prelude/releases/tag/v5.0.0)