### PR TITLE
[v3] Add tags

### DIFF
--- a/config.json
+++ b/config.json
@@ -387,5 +387,16 @@
     }
   ],
   "key_features": [],
-  "tags": []
+  "tags": [
+    "execution_mode/compiled",
+    "paradigm/functional",
+    "platform/linux",
+    "platform/mac",
+    "platform/web",
+    "platform/windows",
+    "runtime/language_specific",
+    "typing/static",
+    "used_for/frontends",
+    "used_for/web_development"
+  ]
 }


### PR DESCRIPTION
In Exercism v3, tracks can be annotated with tags. This allows searching
for tracks with a certain tag combination, making it easy for students
to find an interesting track to join.

Resolves: https://github.com/exercism/purescript/issues/160