### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,25 @@
+{
+  "docs": [
+    {
+      "uuid": "6afa7261-3500-4d76-b9dd-2bff009d1599",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing PureScript locally",
+      "blurb": "Learn how to install PureScript locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "37792dea-e8e2-4ccf-9dce-ab2af6c96100",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn PureScript",
+      "blurb": "An overview of how to get started from scratch with PureScript"
+    },
+    {
+      "uuid": "de68bd29-9059-42e8-8c93-8cbb3ac30cf6",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the PureScript track",
+      "blurb": "Learn how to test your PureScript exercises on Exercism"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
