### PR TITLE
Enable PureScript test-runner

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "active": true,
   "status": {
     "concept_exercises": false,
-    "test_runner": false,
+    "test_runner": true,
     "representer": false,
     "analyzer": false
   },
@@ -14,6 +14,9 @@
     "indent_style": "space",
     "indent_size": 2,
     "highlightjs_language": "haskell"
+  },
+  "test_runner": {
+    "average_run_time": 3
   },
   "files": {
     "solution": [


### PR DESCRIPTION
- Enable test-runner
- Set average run time for test runner to 3 seconds. The run-time is
  based on running all exercise solutions on a 2015 MacBook Pro. Some
  stats (in seconds):

  - minimum: 2.042
  - maximum: 6.005
  - median: 2.280
  - average: 2.436