### PR TITLE
Port unit tests from spec to test-unit

### DIFF
--- a/exercises/concept/booleans/spago.dhall
+++ b/exercises/concept/booleans/spago.dhall
@@ -3,7 +3,7 @@ Welcome to a Spago project!
 You can edit this file as you like.
 -}
 { name = "booleans"
-, dependencies = [ "spec" ]
+, dependencies = [ "console", "effect", "prelude", "psci-support", "test-unit" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/exercises/concept/booleans/test/Main.purs
+++ b/exercises/concept/booleans/test/Main.purs
@@ -2,46 +2,80 @@ module Test.Main where
 
 import Prelude
 
-import Booleans (canExecuteFastAttack, canSpy, canSignalPrisoner, canFreePrisoner)
 import Effect (Effect)
-import Effect.Aff (launchAff_)
-import Test.Spec (describe, it)
-import Test.Spec.Assertions (shouldEqual)
-import Test.Spec.Reporter.Console (consoleReporter)
-import Test.Spec.Runner (runSpec)
+import Test.Unit (TestSuite, describe, it)
+import Test.Unit.Assert (shouldEqual)
+import Test.Unit.Main (runTest)
+
+import Booleans (canExecuteFastAttack, canSpy, canSignalPrisoner, canFreePrisoner)
 
 main :: Effect Unit
-main = launchAff_ $ runSpec [consoleReporter] do
+main = runTest suites
+
+suites :: TestSuite
+suites = do
   describe "Can fast attack" do
-    it "Knight is awake" $ canExecuteFastAttack true `shouldEqual` false
-    it "Knight is asleep" $ canExecuteFastAttack false `shouldEqual` true
+    it "Knight is awake" do
+       canExecuteFastAttack true `shouldEqual` false
+    it "Knight is asleep" do
+       canExecuteFastAttack false `shouldEqual` true
+
   describe "Can spy" do
-    it "Knight is asleep, archer is asleep, prisoner is awake" $ canSpy false false true `shouldEqual` true
-    it "Knight is asleep, archer is awake, prisoner is asleep" $ canSpy false true false `shouldEqual` true
-    it "Knight is awake, archer is asleep, prisoner is asleep" $ canSpy true false false `shouldEqual` true
-    it "Knight is awake, archer is asleep, prisoner is awake" $ canSpy true false true `shouldEqual` true
-    it "Knight is awake, archer is awake, prisoner is asleep" $ canSpy true true false `shouldEqual` true
-    it "Knight is awake, archer is awake, prisoner is awake" $ canSpy true true true `shouldEqual` true
-    it "Knight is asleep, archer is asleep, prisoner is asleep" $ canSpy false false false `shouldEqual` false
+    it "Knight is asleep, archer is asleep, prisoner is awake" do
+       canSpy false false true `shouldEqual` true
+    it "Knight is asleep, archer is awake, prisoner is asleep" do
+       canSpy false true false `shouldEqual` true
+    it "Knight is awake, archer is asleep, prisoner is asleep" do
+       canSpy true false false `shouldEqual` true
+    it "Knight is awake, archer is asleep, prisoner is awake" do
+       canSpy true false true `shouldEqual` true
+    it "Knight is awake, archer is awake, prisoner is asleep" do
+       canSpy true true false `shouldEqual` true
+    it "Knight is awake, archer is awake, prisoner is awake" do
+       canSpy true true true `shouldEqual` true
+    it "Knight is asleep, archer is asleep, prisoner is asleep" do
+       canSpy false false false `shouldEqual` false
+
   describe "Can signal prisoner" do
-    it "Archer is asleep, prisoner is asleep" $ canSignalPrisoner false false `shouldEqual` false
-    it "Archer is asleep, prisoner is awake" $ canSignalPrisoner false true `shouldEqual` true
-    it "Archer is awake, prisoner is asleep" $ canSignalPrisoner true false `shouldEqual` false
-    it "Archer is awake, prisoner is awake" $ canSignalPrisoner true true `shouldEqual` false
+    it "Archer is asleep, prisoner is asleep" do
+      canSignalPrisoner false false `shouldEqual` false
+    it "Archer is asleep, prisoner is awake" do
+      canSignalPrisoner false true `shouldEqual` true
+    it "Archer is awake, prisoner is asleep" do
+      canSignalPrisoner true false `shouldEqual` false
+    it "Archer is awake, prisoner is awake" do
+      canSignalPrisoner true true `shouldEqual` false
+
   describe "Can free prisoner" do
-    it "Knight is asleep, archer is asleep, prisoner is asleep, pet dog is not present" $ canFreePrisoner false false false false `shouldEqual` false
-    it "Knight is asleep, archer is asleep, prisoner is asleep, pet dog is present" $ canFreePrisoner false false false true `shouldEqual` true
-    it "Knight is asleep, archer is asleep, prisoner is awake, pet dog is not present" $ canFreePrisoner false false true false `shouldEqual` true
-    it "Knight is asleep, archer is asleep, prisoner is awake, pet dog is present" $ canFreePrisoner false false true true `shouldEqual` true
-    it "Knight is asleep, archer is awake, prisoner is asleep, pet dog is not present" $ canFreePrisoner false true false false `shouldEqual` false
-    it "Knight is asleep, archer is awake, prisoner is asleep, pet dog is present" $ canFreePrisoner false true false true `shouldEqual` false
-    it "Knight is asleep, archer is awake, prisoner is awake, pet dog is not present" $ canFreePrisoner false true true false `shouldEqual` false
-    it "Knight is asleep, archer is awake, prisoner is awake, pet dog is present" $ canFreePrisoner false true true true `shouldEqual` false
-    it "Knight is awake, archer is asleep, prisoner is asleep, pet dog is not present" $ canFreePrisoner true false false false `shouldEqual` false
-    it "Knight is awake, archer is asleep, prisoner is asleep, pet dog is present" $ canFreePrisoner true false false true `shouldEqual` true
-    it "Knight is awake, archer is asleep, prisoner is awake, pet dog is not present" $ canFreePrisoner true false true false `shouldEqual` false
-    it "Knight is awake, archer is asleep, prisoner is awake, pet dog is present" $ canFreePrisoner true false true true `shouldEqual` true
-    it "Knight is awake, archer is awake, prisoner is asleep, pet dog is not present" $ canFreePrisoner true true false false `shouldEqual` false
-    it "Knight is awake, archer is awake, prisoner is asleep, pet dog is present" $ canFreePrisoner true true false true `shouldEqual` false
-    it "Knight is awake, archer is awake, prisoner is awake, pet dog is not present" $ canFreePrisoner true true true false `shouldEqual` false
-    it "Knight is awake, archer is awake, prisoner is awake, pet dog is present" $ canFreePrisoner true true true true `shouldEqual` false
+    it "Knight is asleep, archer is asleep, prisoner is asleep, pet dog is not present" do
+      canFreePrisoner false false false false `shouldEqual` false
+    it "Knight is asleep, archer is asleep, prisoner is asleep, pet dog is present" do
+      canFreePrisoner false false false true `shouldEqual` true
+    it "Knight is asleep, archer is asleep, prisoner is awake, pet dog is not present" do
+      canFreePrisoner false false true false `shouldEqual` true
+    it "Knight is asleep, archer is asleep, prisoner is awake, pet dog is present" do
+      canFreePrisoner false false true true `shouldEqual` true
+    it "Knight is asleep, archer is awake, prisoner is asleep, pet dog is not present" do
+      canFreePrisoner false true false false `shouldEqual` false
+    it "Knight is asleep, archer is awake, prisoner is asleep, pet dog is present" do
+      canFreePrisoner false true false true `shouldEqual` false
+    it "Knight is asleep, archer is awake, prisoner is awake, pet dog is not present" do
+      canFreePrisoner false true true false `shouldEqual` false
+    it "Knight is asleep, archer is awake, prisoner is awake, pet dog is present" do
+      canFreePrisoner false true true true `shouldEqual` false
+    it "Knight is awake, archer is asleep, prisoner is asleep, pet dog is not present" do
+      canFreePrisoner true false false false `shouldEqual` false
+    it "Knight is awake, archer is asleep, prisoner is asleep, pet dog is present" do
+      canFreePrisoner true false false true `shouldEqual` true
+    it "Knight is awake, archer is asleep, prisoner is awake, pet dog is not present" do
+      canFreePrisoner true false true false `shouldEqual` false
+    it "Knight is awake, archer is asleep, prisoner is awake, pet dog is present" do
+      canFreePrisoner true false true true `shouldEqual` true
+    it "Knight is awake, archer is awake, prisoner is asleep, pet dog is not present" do
+      canFreePrisoner true true false false `shouldEqual` false
+    it "Knight is awake, archer is awake, prisoner is asleep, pet dog is present" do
+      canFreePrisoner true true false true `shouldEqual` false
+    it "Knight is awake, archer is awake, prisoner is awake, pet dog is not present" do
+      canFreePrisoner true true true false `shouldEqual` false
+    it "Knight is awake, archer is awake, prisoner is awake, pet dog is present" do
+      canFreePrisoner true true true true `shouldEqual` false


### PR DESCRIPTION
Prefer using the `test-unit` library over `spec`. The majority of tests
are written using `test-unit` already and we'd like to standardize on
it. The "booleans" concept exercise is the only one using spec.

Addresses #188 