### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/examples/src/HelloWorld.purs
+++ b/exercises/practice/hello-world/examples/src/HelloWorld.purs
@@ -1,8 +1,4 @@
 module HelloWorld where
 
-import Prelude
-import Data.Maybe (Maybe(Just, Nothing))
-
-helloWorld :: Maybe String -> String
-helloWorld Nothing = "Hello, World!"
-helloWorld (Just x) = "Hello, " <> x <> "!"
+helloWorld :: String
+helloWorld = "Hello, World!"

--- a/exercises/practice/hello-world/src/HelloWorld.purs
+++ b/exercises/practice/hello-world/src/HelloWorld.purs
@@ -1,1 +1,4 @@
 module HelloWorld where
+
+helloWorld :: String
+helloWorld = "Goodbye, Mars!"

--- a/exercises/practice/hello-world/test/Main.purs
+++ b/exercises/practice/hello-world/test/Main.purs
@@ -6,7 +6,6 @@ import Effect (Effect)
 import Test.Unit (TestSuite, suite, test)
 import Test.Unit.Main (runTest)
 import Test.Unit.Assert as Assert
-import Data.Maybe (Maybe(Just, Nothing))
 import HelloWorld (helloWorld)
 
 main :: Effect Unit
@@ -15,9 +14,5 @@ main = runTest suites
 suites :: TestSuite
 suites = do
   suite "HelloWorld.helloWorld" do
-    test "Hello with no name" do
-      Assert.equal "Hello, World!" (helloWorld Nothing)
-    test "Hello to a sample name" do
-      Assert.equal "Hello, Alice!" (helloWorld (Just "Alice"))
-    test "Hello to another sample name" do
-      Assert.equal "Hello, Bob!" (helloWorld (Just "Bob"))
+    test "Hello, World!" do
+      Assert.equal "Hello, World!" helloWorld


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46
