### PR TITLE
Align forceful questions test with problem spec

### DIFF
--- a/exercises/practice/bob/examples/src/Bob.purs
+++ b/exercises/practice/bob/examples/src/Bob.purs
@@ -11,35 +11,30 @@ import Partial.Unsafe as Partial
 
 hey :: String -> String
 hey msg =
-  if hasLetters msg && allUppercase msg then
-    "Whoa, chill out!"
+  if isYell msg && isQuestion msg then
+    "Calm down, I know what I'm doing!"
   else if isQuestion msg then
     "Sure."
+  else if isYell msg then
+    "Whoa, chill out!"
   else if isSilence msg then
     "Fine. Be that way!"
   else
     "Whatever."
 
-
-allUppercase :: String -> Boolean
-allUppercase str =
-  String.toUpper str == str
-
-
 isQuestion :: String -> Boolean
 isQuestion =
   testRegex "\\?$"
 
-
-hasLetters :: String -> Boolean
-hasLetters =
-  testRegex "[a-zA-Z]"
-
+isYell :: String -> Boolean
+isYell str = hasLetter str && allUpper str
+  where
+  hasLetter = testRegex "[a-zA-Z]"
+  allUpper s = String.toUpper s == s
 
 isSilence :: String -> Boolean
 isSilence =
   testRegex "^[\\s\\t\\n]*$"
-
 
 testRegex :: String -> String -> Boolean
 testRegex patternStr =

--- a/exercises/practice/bob/test/Main.purs
+++ b/exercises/practice/bob/test/Main.purs
@@ -39,7 +39,7 @@ suites = do
         Bob.hey "It's OK if you don't want to go to the DMV."
 
     test "forceful questions" do
-      Assert.equal "Whoa, chill out!" $
+      Assert.equal "Calm down, I know what I'm doing!" $
         Bob.hey "WHAT THE HELL WERE YOU THINKING?"
 
     test "shouting numbers" do


### PR DESCRIPTION
An additional response was added to the problem specification but the
forceful question unit test was incorrect.

The response should be "Calm down, I know what I'm doing!" because "WHAT
THE HELL WERE YOU THINKING?" is both a question and a yell.

See: exercism/purescript/issues/89 (awaiting to be reopened)